### PR TITLE
fix: escaped the ampersand twice

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,11 +79,11 @@ const highlight = (s) => htmlEscape(s).replace(
 );
 
 const htmlEscape = (s) => s.replace(
+  /&/g, '&amp;'
+).replace(
   />/g, '&gt;'
 ).replace(
   /</g, '&lt;'
-).replace(
-  /&/g, '&amp;'
 ).replace(
   /"/g, '&quot;'
 ).replace(


### PR DESCRIPTION
For example, when there is `>` char, htmlEscape() converts it to `&gt;` first, then picks up `&` and converts the final result to `&amp;gt;` which is incorrect.

After adjusting the escape sequence it works fine now.